### PR TITLE
Expose assets folder as param, update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /build
 /captures
 .externalNativeBuild
+sh.exe.stackdump

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ dependencies {
     .openHelperFactory(new AssetSQLiteOpenHelperFactory())
     .build();
 ```
+Alternatively, if you need precise control over the subfolder under ``assets/`` containing your sqlite database,
+specify the subfolder path as an argument to ``AssetSQLiteOpenHelperFactory`` e.g. if your database is in
+``assets/databases#lang_en`` you would use
+```java
+       Room.databaseBuilder(context.getApplicationContext(),
+                            AppDatabase.class,
+                            "database_name.db")
+       .openHelperFactory(new AssetSQLiteOpenHelperFactory("databases#lang_en"))
+       .build();
+```
 - See samples in this project to show more
 
 ## 👬 Contribution

--- a/library/src/main/java/com/fstyle/library/helper/AssetSQLiteOpenHelper.java
+++ b/library/src/main/java/com/fstyle/library/helper/AssetSQLiteOpenHelper.java
@@ -14,15 +14,17 @@ import android.support.annotation.RequiresApi;
 class AssetSQLiteOpenHelper implements SupportSQLiteOpenHelper {
     private final OpenHelper mDelegate;
 
-    AssetSQLiteOpenHelper(Context context, String name, SQLiteDatabase.CursorFactory factory,
+    AssetSQLiteOpenHelper(Context context, String name,
+                          String assetsDirectory, SQLiteDatabase.CursorFactory factory,
             int version, DatabaseErrorHandler errorHandler, Callback callback) {
-        mDelegate = createDelegate(context, name, factory, version, errorHandler, callback);
+        mDelegate = createDelegate(context, name, assetsDirectory, factory, version, errorHandler, callback);
     }
 
     private OpenHelper createDelegate(Context context, String name,
-            SQLiteDatabase.CursorFactory factory, int version, DatabaseErrorHandler errorHandler,
+                                      String assetsDirectory,
+                                      SQLiteDatabase.CursorFactory factory, int version, DatabaseErrorHandler errorHandler,
             final Callback callback) {
-        return new OpenHelper(context, name, factory, version, errorHandler) {
+        return new OpenHelper(context, name, assetsDirectory, factory, version, errorHandler) {
             @Override
             public final void onCreate(SQLiteDatabase sqLiteDatabase) {
                 mWrappedDb = new FrameworkSQLiteDatabase(sqLiteDatabase);
@@ -82,9 +84,9 @@ class AssetSQLiteOpenHelper implements SupportSQLiteOpenHelper {
 
         FrameworkSQLiteDatabase mWrappedDb;
 
-        OpenHelper(Context context, String name, SQLiteDatabase.CursorFactory factory, int version,
-                DatabaseErrorHandler errorHandler) {
-            super(context, name, null, factory, version, errorHandler);
+        OpenHelper(Context context, String name, String assetsDirectory, SQLiteDatabase.CursorFactory factory, int version,
+                   DatabaseErrorHandler errorHandler) {
+            super(context, name, assetsDirectory, null, factory, version, errorHandler);
         }
 
         SupportSQLiteDatabase getWritableSupportDatabase() {

--- a/library/src/main/java/com/fstyle/library/helper/AssetSQLiteOpenHelperFactory.java
+++ b/library/src/main/java/com/fstyle/library/helper/AssetSQLiteOpenHelperFactory.java
@@ -9,9 +9,19 @@ import android.database.sqlite.SQLiteDatabase;
  */
 
 public class AssetSQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Factory {
+    private String assetDirectory = "";
+
+    public AssetSQLiteOpenHelperFactory() {
+        this(SQLiteAssetHelper.ASSET_DB_PATH);
+    }
+
+    public AssetSQLiteOpenHelperFactory(String assetDirectory) {
+        this.assetDirectory = assetDirectory;
+    }
+
     @Override
     public SupportSQLiteOpenHelper create(SupportSQLiteOpenHelper.Configuration configuration) {
-        return new AssetSQLiteOpenHelper(configuration.context, configuration.name, null,
+        return new AssetSQLiteOpenHelper(configuration.context, configuration.name, assetDirectory, null,
                 configuration.callback.version, new DatabaseErrorHandler() {
             @Override
             public void onCorruption(SQLiteDatabase sqLiteDatabase) {

--- a/library/src/main/java/com/fstyle/library/helper/SQLiteAssetHelper.java
+++ b/library/src/main/java/com/fstyle/library/helper/SQLiteAssetHelper.java
@@ -57,7 +57,7 @@ import java.util.zip.ZipInputStream;
 class SQLiteAssetHelper extends SQLiteOpenHelper {
 
     private static final String TAG = SQLiteAssetHelper.class.getSimpleName();
-    private static final String ASSET_DB_PATH = "databases";
+    public static final String ASSET_DB_PATH = "databases";
 
     private final Context mContext;
     private final String mName;
@@ -91,7 +91,8 @@ class SQLiteAssetHelper extends SQLiteOpenHelper {
      * SQL file(s) contained within the application assets folder will be used to
      * upgrade the database
      */
-    public SQLiteAssetHelper(Context context, String name, String storageDirectory,
+    public SQLiteAssetHelper(Context context, String name,
+                             String assetsDirectory, String storageDirectory,
             CursorFactory factory, int version, DatabaseErrorHandler errorHandler) {
         super(context, name, factory, version, errorHandler);
 
@@ -103,13 +104,13 @@ class SQLiteAssetHelper extends SQLiteOpenHelper {
         mFactory = factory;
         mNewVersion = version;
 
-        mAssetPath = ASSET_DB_PATH + "/" + name;
+        mAssetPath = assetsDirectory + "/" + name;
         if (storageDirectory != null) {
             mDatabasePath = storageDirectory;
         } else {
             mDatabasePath = context.getApplicationInfo().dataDir + "/databases";
         }
-        mUpgradePathFormat = ASSET_DB_PATH + "/" + name + "_upgrade_%s-%s.sql";
+        mUpgradePathFormat = assetsDirectory + "/" + name + "_upgrade_%s-%s.sql";
     }
 
     /**
@@ -127,7 +128,7 @@ class SQLiteAssetHelper extends SQLiteOpenHelper {
      * upgrade the database
      */
     public SQLiteAssetHelper(Context context, String name, CursorFactory factory, int version) {
-        this(context, name, null, factory, version, null);
+        this(context, name, ASSET_DB_PATH, null, factory, version, null);
     }
 
     /**


### PR DESCRIPTION
Expose assets folder as param

In case user needs control over "assets/" subfolder naming convention

Update docs to indicate new usage flow